### PR TITLE
fixed dependency, fixed tests

### DIFF
--- a/de.unistuttgart.iste.sqa.oo.hamstersimulator.testframework/pom.xml
+++ b/de.unistuttgart.iste.sqa.oo.hamstersimulator.testframework/pom.xml
@@ -28,13 +28,12 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.5.2</version>
+            <version>1.7.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.7.2</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/de.unistuttgart.iste.sqa.oo.hamstersimulator.testframework/src/test/java/de/unistuttgart/iste/sqa/oo/hamstersimulator/testframework/HamsterGameTestExtensionTest.java
+++ b/de.unistuttgart.iste.sqa.oo.hamstersimulator.testframework/src/test/java/de/unistuttgart/iste/sqa/oo/hamstersimulator/testframework/HamsterGameTestExtensionTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * Tests the extension functionality
  */
 @ExtendWith(HamsterGameResolver.class)
-@HamsterTest(game = "TestSimpleHamsterGame")
+@HamsterTest(game = "de.unistuttgart.iste.sqa.oo.hamstersimulator.testframework.TestSimpleHamsterGame")
 public class HamsterGameTestExtensionTest extends HamsterGameTestExtensionTestBase {
     /**
      * Tests that the BeforeEach method in the super class works as expected

--- a/de.unistuttgart.iste.sqa.oo.hamstersimulator.testframework/src/test/java/de/unistuttgart/iste/sqa/oo/hamstersimulator/testframework/gamestate/RecordingHamsterGameTestEnvironmentTest.java
+++ b/de.unistuttgart.iste.sqa.oo.hamstersimulator.testframework/src/test/java/de/unistuttgart/iste/sqa/oo/hamstersimulator/testframework/gamestate/RecordingHamsterGameTestEnvironmentTest.java
@@ -25,7 +25,7 @@ import javafx.collections.ObservableList;
  * of the hamster on the territory.
  * @author Steffen Becker
  */
-@HamsterTest(game = "TestSimpleHamsterGame")
+@HamsterTest(game = "de.unistuttgart.iste.sqa.oo.hamstersimulator.testframework.gamestate.TestSimpleHamsterGame")
 @ExtendWith(HamsterGameResolver.class)
 public final class RecordingHamsterGameTestEnvironmentTest {
 

--- a/de.unistuttgart.iste.sqa.oo.hamstersimulator.testframework/src/test/java/de/unistuttgart/iste/sqa/oo/hamstersimulator/testframework/ltl/LTLChecksTests.java
+++ b/de.unistuttgart.iste.sqa.oo.hamstersimulator.testframework/src/test/java/de/unistuttgart/iste/sqa/oo/hamstersimulator/testframework/ltl/LTLChecksTests.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Steffen Becker
  */
-@HamsterTest(game = "TestSimpleHamsterGame")
+@HamsterTest(game = "de.unistuttgart.iste.sqa.oo.hamstersimulator.testframework.ltl.TestSimpleHamsterGame")
 @ExtendWith(HamsterGameResolver.class)
 public final class LTLChecksTests {
 


### PR DESCRIPTION
- A wrong dependency version for junit-platform-launcher caused tests not to be executed (in the simulator itself, which resulted in no tests executed in the testframework module, the same happened for external tests using the framework)
- Replaced non-fully-qualified classnames in the HamsterTest annotation because they did not seem to work (I'm not sure if this is something new, or maybe these tests were never executed due to the bug above)