### PR TITLE
set focus to content when popover is shown

### DIFF
--- a/de.hamstersimulator.objectsfirst.inspector/src/main/java/de/hamstersimulator/objectsfirst/inspector/ui/CardListView.java
+++ b/de.hamstersimulator.objectsfirst.inspector/src/main/java/de/hamstersimulator/objectsfirst/inspector/ui/CardListView.java
@@ -125,6 +125,7 @@ public abstract class CardListView<T extends HideableViewModel> extends FlowPane
         popOver.show(owner);
         popOver.setOnHidden(event -> owner.setSelected(false));
         this.currentPopOver = popOver;
+        content.requestFocus();
     }
 
     protected abstract ObservableStringValue getCardText(final T item);


### PR DESCRIPTION
- Fixes a bug, where if the popover of another card is shown, a specific item of the Accordion is not clickable. It seems like it has and hasn't the focus at the same time. 