### PR TITLE
Fixed instances of accessible classes not being accessible

### DIFF
--- a/de.hamstersimulator.objectsfirst.inspector/src/main/java/de/hamstersimulator/objectsfirst/inspector/model/ClassFactory.java
+++ b/de.hamstersimulator.objectsfirst.inspector/src/main/java/de/hamstersimulator/objectsfirst/inspector/model/ClassFactory.java
@@ -45,7 +45,7 @@ public final class ClassFactory {
         }
         if (this.hasViewModelForClass(cls)) {
             final ClassViewModel viewModel = this.classViewModelLookup.get(cls);
-            viewModel.setInstancesAccessibleProperty().set(setInstancesAccessible);
+            viewModel.setInstancesAccessibleProperty().set(viewModel.setInstancesAccessibleProperty().get() || setInstancesAccessible);
             if (setAccessible && !viewModel.hasPrivateMembersProperty().get()) {
                 this.updateClassMemberListAccessible(cls, viewModel);
             }


### PR DESCRIPTION
Instances of classes that were made accessible (e.g. those in the same package as the simple hamster game) weren't accessible meaning non-public methods weren't visible.