### PR TITLE
Bugfix: log and macOS ARM

### DIFF
--- a/de.hamstersimulator.objectsfirst.core/pom.xml
+++ b/de.hamstersimulator.objectsfirst.core/pom.xml
@@ -19,7 +19,7 @@
 	    <dependency>
       		<groupId>org.openjfx</groupId>
     		<artifactId>javafx-base</artifactId>
-    		<version>17.0.1</version>
+    		<version>17.0.2-ea+1</version>
   		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/de.hamstersimulator.objectsfirst.inspector/pom.xml
+++ b/de.hamstersimulator.objectsfirst.inspector/pom.xml
@@ -31,13 +31,13 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx</artifactId>
-            <version>17.0.1</version>
+            <version>17.0.2-ea+1</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>17.0.1</version>
+            <version>17.0.2-ea+1</version>
         </dependency>
         <dependency>
             <groupId>de.hamstersimulator.objectsfirst</groupId>

--- a/de.hamstersimulator.objectsfirst.server/pom.xml
+++ b/de.hamstersimulator.objectsfirst.server/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-base</artifactId>
-            <version>17.0.1</version>
+            <version>17.0.2-ea+1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/de.hamstersimulator.objectsfirst.ui/pom.xml
+++ b/de.hamstersimulator.objectsfirst.ui/pom.xml
@@ -22,13 +22,13 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx</artifactId>
-            <version>17.0.1</version>
+            <version>17.0.2-ea+1</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>17.0.1</version>
+            <version>17.0.2-ea+1</version>
         </dependency>
     </dependencies>
 </project>

--- a/de.hamstersimulator.objectsfirst.ui/src/main/java/de/hamstersimulator/objectsfirst/ui/javafx/GameSceneController.java
+++ b/de.hamstersimulator.objectsfirst.ui/src/main/java/de/hamstersimulator/objectsfirst/ui/javafx/GameSceneController.java
@@ -5,11 +5,11 @@ import de.hamstersimulator.objectsfirst.adapter.HamsterGameController;
 import de.hamstersimulator.objectsfirst.adapter.observables.ObservableLogEntry;
 import de.hamstersimulator.objectsfirst.datatypes.Mode;
 import javafx.application.Platform;
-import javafx.beans.property.ReadOnlyListProperty;
+import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
-import javafx.scene.Parent;
 import javafx.scene.control.Button;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
@@ -19,24 +19,49 @@ import javafx.scene.control.ToolBar;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.paint.Color;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.logging.LogManager;
+
+/**
+ * Controller for the main game scene
+ *
+ * Note: The static constructor sets the log level of the javafx.scene.control logger to WARNING to
+ * hide a INFO message caused by the log list
+ */
 public class GameSceneController {
+
+    static {
+        final String logLevelString = "javafx.scene.control.level = WARNING";
+        final InputStream logLevelStream = new ByteArrayInputStream(logLevelString.getBytes(StandardCharsets.UTF_8));
+        // Note: this is taken from the LogManager documentation and merges the old and new configuration
+        final Function<String, BiFunction<String, String, String>> mapper = (k) -> ((o, n) -> n == null ? o : n);
+
+        try {
+            LogManager.getLogManager().updateConfiguration(logLevelStream, mapper);
+        } catch (IOException e) {
+            // Do nothing, in this case we failed to update the log level
+        }
+    }
 
     class CellFormat extends ListCell<ObservableLogEntry> {
         @Override
         protected void updateItem(final ObservableLogEntry item, final boolean empty) {
-            Platform.runLater(() -> {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
+            super.updateItem(item, empty);
+            if (empty || item == null) {
+                setText(null);
+            } else {
+                setText(item.getMessage());
+                if (hamsterGrid.hamsterToColorPos.containsKey(item.getHamster())) {
+                    setTextFill(TileNode.hamsterColors[hamsterGrid.hamsterToColorPos.get(item.getHamster())]);
                 } else {
-                    setText(item.getMessage());
-                    if (hamsterGrid.hamsterToColorPos.containsKey(item.getHamster())) {
-                        setTextFill(TileNode.hamsterColors[hamsterGrid.hamsterToColorPos.get(item.getHamster())]);
-                    } else {
-                        setTextFill(Color.BLACK);
-                    }
+                    setTextFill(Color.BLACK);
                 }
-            });
+            }
         }
     }
 
@@ -77,7 +102,6 @@ public class GameSceneController {
         new Thread(gameController::resume).start();
     }
 
-    @SuppressWarnings("unchecked")
     public void connectToGame(final HamsterGameViewModel hamsterGameViewModel) {
         this.gameController = hamsterGameViewModel.getGameController();
         this.hamsterGrid.bindToTerritory(hamsterGameViewModel.getTerritory());
@@ -87,21 +111,27 @@ public class GameSceneController {
         this.redo.disableProperty().bind(this.gameController.canRedoProperty().not());
         this.speed.valueProperty().bindBidirectional(this.gameController.speedProperty());
         this.log.setCellFactory(list -> new CellFormat());
-        this.log.itemsProperty().bind((ReadOnlyListProperty<ObservableLogEntry>) hamsterGameViewModel.getLog().logProperty());
-        this.log.getItems().addListener((ListChangeListener<ObservableLogEntry>) changeListener -> {
-            changeListener.next();
-            final int size = log.getItems().size();
-            if (size > 1) {
-                JavaFXUtil.blockingExecuteOnFXThread(() -> {
-                    final Parent virtualFlow = (Parent) log.getChildrenUnmodifiable().get(0);
-                    final Parent group = (Parent) virtualFlow.getChildrenUnmodifiable().get(1);
-                    final Parent cell = (Parent) group.getChildrenUnmodifiable().get(0);
-                    final ListCell<ObservableLogEntry> listCell = (ListCell<ObservableLogEntry>) cell;
-                    final int visibleCells = (int) (log.getHeight() / listCell.getHeight());
-                    log.scrollTo(Math.max(0, size - visibleCells));
-                });
-            }
+        hamsterGameViewModel.getLog().logProperty().addListener((ListChangeListener<ObservableLogEntry>) change -> {
+            JavaFXUtil.blockingExecuteOnFXThread(() -> {
+                updateLogEntries(hamsterGameViewModel);
+            });
         });
+    }
+
+    /**
+     * Updates the log entries based on the current log entries
+     * @param hamsterGameViewModel the ViewModel used to get the log entries
+     */
+    private void updateLogEntries(final HamsterGameViewModel hamsterGameViewModel) {
+        final ObservableList<ObservableLogEntry> logEntries = FXCollections.observableArrayList();
+        logEntries.addAll(hamsterGameViewModel.getLog().logProperty());
+        this.log.setItems(logEntries);
+        final int size = log.getItems().size();
+        if (size > 1) {
+            Platform.runLater(() -> {
+                this.log.scrollTo(size - 1);
+            });
+        }
     }
 
 }

--- a/de.hamstersimulator.objectsfirst.ui/src/main/java/de/hamstersimulator/objectsfirst/ui/javafx/GameSceneController.java
+++ b/de.hamstersimulator.objectsfirst.ui/src/main/java/de/hamstersimulator/objectsfirst/ui/javafx/GameSceneController.java
@@ -48,7 +48,8 @@ public class GameSceneController {
         try {
             LogManager.getLogManager().updateConfiguration(logLevelStream, mapper);
         } catch (IOException e) {
-            // Do nothing, in this case we failed to update the log level
+            final System.Logger logger = System.getLogger(GameSceneController.class.getName());
+            logger.log(System.Logger.Level.INFO, "Failed to update JavaFX Controls log level to INFO");
         }
     }
 

--- a/de.hamstersimulator.objectsfirst.ui/src/main/java/de/hamstersimulator/objectsfirst/ui/javafx/GameSceneController.java
+++ b/de.hamstersimulator.objectsfirst.ui/src/main/java/de/hamstersimulator/objectsfirst/ui/javafx/GameSceneController.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.logging.LogManager;
@@ -38,8 +39,11 @@ public class GameSceneController {
     static {
         final String logLevelString = "javafx.scene.control.level = WARNING";
         final InputStream logLevelStream = new ByteArrayInputStream(logLevelString.getBytes(StandardCharsets.UTF_8));
-        // Note: this is taken from the LogManager documentation and merges the old and new configuration
-        final Function<String, BiFunction<String, String, String>> mapper = (k) -> ((o, n) -> n == null ? o : n);
+        final Function<String, BiFunction<String, String, String>> mapper = (category) -> {
+            return (oldValue, newValue) -> {
+                return Optional.ofNullable(newValue).orElse(oldValue);
+            };
+        };
 
         try {
             LogManager.getLogManager().updateConfiguration(logLevelStream, mapper);

--- a/de.hamstersimulator.objectsfirst.ui/src/main/java/de/hamstersimulator/objectsfirst/ui/javafx/GameSceneController.java
+++ b/de.hamstersimulator.objectsfirst.ui/src/main/java/de/hamstersimulator/objectsfirst/ui/javafx/GameSceneController.java
@@ -49,7 +49,7 @@ public class GameSceneController {
             LogManager.getLogManager().updateConfiguration(logLevelStream, mapper);
         } catch (IOException e) {
             final System.Logger logger = System.getLogger(GameSceneController.class.getName());
-            logger.log(System.Logger.Level.INFO, "Failed to update JavaFX Controls log level to INFO");
+            logger.log(System.Logger.Level.INFO, "Failed to update JavaFX Controls log level to WARNING");
         }
     }
 

--- a/de.hamstersimulator.objectsfirst.ui/src/main/java/module-info.java
+++ b/de.hamstersimulator.objectsfirst.ui/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module de.hamstersimulator.objectsfirst.ui {
     requires javafx.controls;
     requires javafx.fxml;
     requires de.hamstersimulator.objectsfirst.core;
+    requires java.logging;
 
     opens de.hamstersimulator.objectsfirst.ui.javafx to javafx.fxml;
     opens de.hamstersimulator.objectsfirst.ui.ressources.fxml;


### PR DESCRIPTION
- increases javafx version because of https://bugs.openjdk.java.net/browse/JDK-8275723
- prevents visual glitches in log for a large amount of log entries and log entries with different sizes
- hides log INFO message from VirtualFlow if undo is used with a large amount of log entries